### PR TITLE
Minor changes

### DIFF
--- a/ssk2/easyInputs/oneStickOneTouch.lua
+++ b/ssk2/easyInputs/oneStickOneTouch.lua
@@ -48,7 +48,7 @@ local function create( group, params )
 	local keyboardEn	= fnn(params.keyboardEn, false)	
 
 	local stickEventName 	= params.stickEventName or "onJoystick"
-	local joyParams 	= params.joyParams or params.joyParams or {}
+	local joyParams 	= params.joyParams or {}
 
 
 	local function onTouch( self, event )
@@ -85,8 +85,8 @@ local function create( group, params )
 	joyParams.inUseAlpha = fnn( joyParams.inUseAlpha, 1 )
 	joyParams.notInUseAlpha = fnn( joyParams.notInUseAlpha, 0.25 )
 
-	local sx = centerX - fullw/2 + 60
-	local sy = centerY + fullh/2 - 60
+	local sx = centerX - fullw/2 + ( joyParams.outerRadius or 60 )
+	local sy = centerY + fullh/2 - ( joyParams.outerRadius or 60 )
 
 	local inputHelper = display.newGroup()
 	group:insert(inputHelper)


### PR DESCRIPTION
Hi,

I also found some mistakes in doc:

https://roaminggamer.github.io/RGDocs/pages/SSK2/libraries/easy_inputs/#joystick-factory

1. Is: 

nx, ny - Normalized version of vx and vy respecrtively.

Should be: 

respectively

2. Is: 

joystick.create( nil, left + 30, bottom - 30 )

Should be: 

ssk.easyInputs.joystick.create( nil, left + 30, bottom - 30 )

3 .Is: 

ssk.easyInputs.joystick.create( group, x, y, joyParams  )

Should be:

ssk.easyInputs.joystick.create( group, x, y, params  )

It make more sense use params name since it appear later i.e params.alpha :)

4. Github: 

local stickStrokeWidth	= params.stickStrokeWidth or 0

Doc: 

stickStrokeWidth (4) - Stroke width.

5. I did not find deadZoneRadius parameter in documentation on 
https://roaminggamer.github.io/RGDocs/pages/SSK2/libraries/easy_inputs/#joystick-factory

Is: 

outerRadius (outerRadius/2) - Radius of dead zone.

Should be:

deadZoneRadius (outerRadius/2) - Radius of dead zone. 

Your library is great I definitely use it in my next game :)

Have a nice day:)

ldurniat